### PR TITLE
Wofi window switcher for Sway

### DIFF
--- a/.local/bin/scripts/wofi/window_selector.sh
+++ b/.local/bin/scripts/wofi/window_selector.sh
@@ -5,10 +5,33 @@ windows=$(swaymsg -t get_tree | jq -r '
 	recurse(.nodes[]?) |
 		recurse(.floating_nodes[]?) |
 		select(.type=="con"), select(.type=="floating_con") |
-			(.id | tostring) + " " + .app_id + ": " + .name')
+			" " + .app_id + ": " + .name' | sed '/ $/d;s/\ ://;s/^\ //')
+
+# Find out how many lines wofi needs
+length=$(echo "$windows" | wc -l)
 
 # Select window with wofi
-selected=$(printf "$windows" | wofi -d -i -p "Switch to:" | awk '{print $1}')
+selected=$(printf %s "$windows" | wofi --dmenu --insensitive --lines "$length" -p "Switch to:")
+
+# Make it work with Xwayland or Wayland apps
+case "$selected" in
+	*:\ * )
+		theapp=$(printf '%s' "$selected" | cut -d: -f1 )
+		thename=$(printf '%s' "$selected" | cut -d: -f2 | sed 's/\ //' )
+		identity=$(swaymsg -t get_tree | jq -r '
+			recurse(.nodes[]?) |
+				recurse(.floating_nodes[]?) |
+				select(.app_id=="'"$theapp"'" and .name=="'"$thename"'") |
+					(.id | tostring)')
+		;;
+	* )
+		identity=$(swaymsg -t get_tree | jq -r '
+			recurse(.nodes[]?) |
+				recurse(.floating_nodes[]?) |
+				select(.name=="'"$selected"'") |
+					(.id | tostring)')
+		;;
+esac
 
 # Tell sway to focus said window
-swaymsg [con_id="$selected"] focus
+swaymsg [con_id="$identity"] focus


### PR DESCRIPTION
Hello! I was looking for a window switcher for Sway and happened upon yours. I added some things to the script that I wanted to share:
- Automatically change the number of lines Wofi uses to fit the number of windows open
- remove entries that don't seem to have a name or an app_id
- clean up the look of the list of entries to be a little more uniform
By way of example, here's the before and after for these changes on my system:
![wofi-old](https://user-images.githubusercontent.com/31171855/122414269-018b2c80-cf55-11eb-8849-d00aae819b20.png)
![wofi-new](https://user-images.githubusercontent.com/31171855/122414294-06e87700-cf55-11eb-8062-ecc49017d60a.png)

There may be a simpler/cleaner way to accomplish these things, but this seems to work fairly well for me.